### PR TITLE
fix beignet build target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,11 +62,11 @@ else (BEIGNET_INSTALL_DIR STREQUAL "${CMAKE_INSTALL_PREFIX}/lib/beignet/")
 endif (BEIGNET_INSTALL_DIR STREQUAL "${CMAKE_INSTALL_PREFIX}/lib/beignet/")
 
 # Force Release with debug info
-if (NOT CMAKE_BUILD_TYPE)
-  set (CMAKE_BUILD_TYPE RelWithDebInfo)
-endif (NOT CMAKE_BUILD_TYPE)
-set (CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "assure config" FORCE)
-message(STATUS "Building mode: " ${CMAKE_BUILD_TYPE})
+# if (NOT CMAKE_BUILD_TYPE)
+#  set (CMAKE_BUILD_TYPE RelWithDebInfo)
+# endif (NOT CMAKE_BUILD_TYPE)
+#set (CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "assure config" FORCE)
+#message(STATUS "Building mode: " ${CMAKE_BUILD_TYPE})
 
 # XXX now hard coded to enable the clamp to border workaround for IVB.
 ADD_DEFINITIONS(-DGEN7_SAMPLER_CLAMP_BORDER_WORKAROUND)

--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -15,9 +15,9 @@ set (GBE_USE_BLOB false CACHE bool "Compile everything from one big file")
 
 
 # Force Release with debug info
-if (NOT CMAKE_BUILD_TYPE)
-  set (CMAKE_BUILD_TYPE RelWithDebInfo)
-endif (NOT CMAKE_BUILD_TYPE)
+#if (NOT CMAKE_BUILD_TYPE)
+#  set (CMAKE_BUILD_TYPE RelWithDebInfo)
+#endif (NOT CMAKE_BUILD_TYPE)
 set (CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "assure config" FORCE)
 message(STATUS "Building mode: " ${CMAKE_BUILD_TYPE})
 

--- a/utests/CMakeLists.txt
+++ b/utests/CMakeLists.txt
@@ -16,9 +16,9 @@ if (NOT NOT_BUILD_STAND_ALONE_UTEST)
   ENDIF(OPENCL_FOUND)
 
   # Force Release with debug info
-  if (NOT CMAKE_BUILD_TYPE)
-    set (CMAKE_BUILD_TYPE RelWithDebInfo)
-  endif (NOT CMAKE_BUILD_TYPE)
+  #if (NOT CMAKE_BUILD_TYPE)
+  #  set (CMAKE_BUILD_TYPE RelWithDebInfo)
+  #endif (NOT CMAKE_BUILD_TYPE)
   message(STATUS "Building mode: " ${CMAKE_BUILD_TYPE})
 
   set (CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "assure config" FORCE)


### PR DESCRIPTION
This PR addressed Beignet CMakeList.txt file that set wrong CMAKE_BUILD_TYPE flags that affects g2o CMakeList.txt file to pickup the wrong build artifacts in the debian package.
